### PR TITLE
Fixed NumericTextField validate()

### DIFF
--- a/src/main/java/dk/eamv/ferrari/sharedcomponents/filter/forms/NumericTextField.java
+++ b/src/main/java/dk/eamv/ferrari/sharedcomponents/filter/forms/NumericTextField.java
@@ -5,25 +5,36 @@ import javafx.scene.control.TextField;
 public class NumericTextField extends TextField {
     @Override
     public void replaceText(int start, int end, String text) {
-        if (validate(text)) {
-            super.replaceText(start, end, text);
+        // Save the previous text for restoration if invalid input
+        String prev = getText();
+        super.replaceText(start, end, text.trim());
+
+        // Validate the text, reset the text and caret if not numeric
+        if (!validate(getText())) {
+            int position = getCaretPosition();
+            setText(prev);
+            positionCaret(position);
         }
     }
 
-    @Override
-    public void replaceSelection(String text) {
-        if (validate(text)) {
-            super.replaceSelection(text);
-        }
-    }
-
+    // Validate if the text is numeric
     private boolean validate(String text) {
-        boolean isValid = true;
+        // If it's empty there's no reason to try parsing it.
+        if (text.isEmpty()) {
+            return true;
+        }
+
+        // If it's blank (contains spaces) then it's not numeric
+        if (text.isBlank()) {
+            return false;
+        }
+
+        // If it can be parsed to a double, then it works
         try {
             Double.parseDouble(text);
+            return true;
         } catch (NumberFormatException exception) {
-            isValid = false;
+            return false;
         }
-        return isValid;
     }
 }


### PR DESCRIPTION
Previously it would not accept a dot in the text. This was due to the validate() only receiving one character at a time. Now we give it the entire text and save the previous, so in case it isn't a numeric, then the text is restored.

We also restore the caret position on error.

Now we also disallow spaces in a NumericTextField.

Also removed replaceSelection(), since it calls replaceText() any way. So we only need to override a single function.